### PR TITLE
Add implements for Service Impl Class and replace "LocationService" with "ILocationService" in LocationController for better practise.

### DIFF
--- a/src/main/java/com/hpoyraz/locationbyip/controller/LocationController.java
+++ b/src/main/java/com/hpoyraz/locationbyip/controller/LocationController.java
@@ -2,6 +2,7 @@ package com.hpoyraz.locationbyip.controller;
 
 import com.hpoyraz.locationbyip.model.Location;
 import com.hpoyraz.locationbyip.service.impl.LocationService;
+import com.hpoyraz.locationbyip.service.interfaces.ILocationService;
 import com.hpoyraz.locationbyip.util.constants.ApiConstants;
 import lombok.RequiredArgsConstructor;;
 import org.springframework.http.ResponseEntity;
@@ -14,7 +15,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @RequiredArgsConstructor
 @RequestMapping(ApiConstants.Location.BASE_URL)
 public class LocationController {
-    private final LocationService locationService;
+    private final ILocationService locationService;
 
     @GetMapping("/{ipAddress}")
     public ResponseEntity<Location> getLocationByIP(@PathVariable String ipAddress) {

--- a/src/main/java/com/hpoyraz/locationbyip/service/impl/LocationService.java
+++ b/src/main/java/com/hpoyraz/locationbyip/service/impl/LocationService.java
@@ -2,6 +2,7 @@ package com.hpoyraz.locationbyip.service.impl;
 
 import com.hpoyraz.locationbyip.exception.LocationGeoIp2Exception;
 import com.hpoyraz.locationbyip.exception.LocationIOException;
+import com.hpoyraz.locationbyip.service.interfaces.ILocationService;
 import com.hpoyraz.locationbyip.util.constants.DatabaseConstants;
 import com.hpoyraz.locationbyip.exception.DistrictnameNotFoundException;
 import com.hpoyraz.locationbyip.model.Location;
@@ -18,7 +19,10 @@ import java.net.InetAddress;
 import java.util.List;
 
 @Service
-public class LocationService {
+public class LocationService implements ILocationService {
+
+
+    @Override
     public Location getLocationByIP(String ipAddress) {
         try {
             File database = new File(DatabaseConstants.dbLocation);


### PR DESCRIPTION
I replaced "LocationService" with "ILocationService" in the LocationController for better flexibility and readability. This naming convention shows it's an interface, improving code maintenance.
I also noticed the Service Impl class didn't implement the service interface, which could cause issues with polymorphism and dependency injection. I updated it to implement the interface, ensuring the design pattern is followed and best practices are met.